### PR TITLE
Create local HTTP server for read-only request testing.

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -40,6 +40,9 @@ jobs:
     - name: Run local s3 with pytest
       run: |
         python -m pytest tests --cloud local_s3
+    - name: Run local http with pytest
+      run: |
+        python -m pytest tests --cloud http
     # - name: Run ABFS unit tests with pytest
     #   run: |
     #     python -m pytest tests --cloud abfs

--- a/.github/workflows/testing-and-coverage.yml
+++ b/.github/workflows/testing-and-coverage.yml
@@ -32,6 +32,9 @@ jobs:
     - name: Run local s3 with pytest
       run: |
         python -m pytest tests --cloud local_s3
+    - name: Run local http with pytest
+      run: |
+        python -m pytest tests --cloud http
     # - name: Run ABFS unit tests with pytest
     #   run: |
     #     python -m pytest tests --cloud abfs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,8 @@ build-backend = "setuptools.build_meta"
 [tool.pytest.ini_options]
 markers = [
     "dask: mark tests as having a dask client runtime dependency",
+    "write_to_cloud: test writes to cloud - skipped for read-only file system testing",
+    "requires_range: test requires a range request - skipped FOR NOW for http",
 ]
 [tool.black]
 line-length = 110

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,10 +35,42 @@ def cloud(request):
     return request.config.getoption("--cloud")
 
 
+@pytest.fixture(scope="session", name="http_server")
+def http_server(cloud, local_cloud_data_dir):
+    if cloud != "http":
+        yield None
+        return
+
+    requests = pytest.importorskip("requests")
+    # pylint: disable=consider-using-with
+    proc = subprocess.Popen(
+        shlex.split(f"python -m http.server -d {local_cloud_data_dir}"),
+        stderr=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+    )
+    endpoint_uri = "http://0.0.0.0:8000/"
+    try:
+        timeout = 5
+        while timeout > 0:
+            try:
+                r = requests.get(endpoint_uri, timeout=10)
+                if r.ok:
+                    break
+            except Exception:  # pylint: disable=broad-except
+                pass
+            timeout -= 0.1
+            time.sleep(0.1)
+        yield endpoint_uri
+    finally:
+        proc.terminate()
+        proc.wait()
+
+
 @pytest.fixture(scope="session", name="s3_server")
 def s3_server(cloud):
     if cloud != "local_s3":
         yield {}
+        return
     # writable local S3 system
     os.environ["BOTO_CONFIG"] = "/dev/null"
     os.environ["AWS_ACCESS_KEY_ID"] = "testing"
@@ -81,7 +113,7 @@ def s3_server(cloud):
 
 
 @pytest.fixture(scope="session", name="cloud_path")
-def cloud_path(cloud, s3_server, local_cloud_data_dir):
+def cloud_path(cloud, s3_server, local_cloud_data_dir, http_server):
     if cloud == "abfs":
         storage_options = {
             "account_name": os.environ.get("ABFS_LINCCDATA_ACCOUNT_NAME"),
@@ -106,6 +138,11 @@ def cloud_path(cloud, s3_server, local_cloud_data_dir):
         assert root_dir.exists()
         return root_dir
 
+    if cloud == "http":
+        root_dir = UPath(http_server)
+        assert root_dir.exists()
+        return root_dir
+
     raise NotImplementedError("Cloud format not implemented for tests!")
 
 
@@ -123,6 +160,20 @@ def storage_options(cloud, s3_server):
         return s3so
 
     return {}
+
+
+def pytest_collection_modifyitems(session, items):
+    """Add SKIP directive to tests that will write to cloud IF running
+    tests against a read-only file system (e.g. HTTP)"""
+    cloud = session.config.getoption("--cloud")
+    if cloud in ("http"):
+        skip_write = pytest.mark.skip(reason="Skipping write tests for read-only file system.")
+        skip_range = pytest.mark.skip(reason="Skipping index tests for non-range reads.")
+        for item in items:
+            for _ in item.iter_markers(name="write_to_cloud"):
+                item.add_marker(skip_write)
+            for _ in item.iter_markers(name="requires_range"):
+                item.add_marker(skip_range)
 
 
 @pytest.fixture(scope="session")
@@ -185,6 +236,11 @@ def small_sky_margin_dir_cloud(cloud_path):
 @pytest.fixture(scope="session", name="tmp_dir_cloud")
 def tmp_dir_cloud(cloud_path, cloud):
     """Create a single client for use by all unit test cases."""
+    ## Read-only filesystem
+    if cloud in ("http"):
+        yield None
+        return
+
     real_directories = True
     if cloud in ("local_s3"):
         real_directories = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,7 @@ SMALL_SKY_DIR_NAME = "small_sky"
 
 
 def pytest_addoption(parser):
-    parser.addoption("--cloud", action="store", default="local_s3")
+    parser.addoption("--cloud", action="store")
 
 
 @pytest.fixture(scope="session", name="cloud")
@@ -166,6 +166,10 @@ def pytest_collection_modifyitems(session, items):
     """Add SKIP directive to tests that will write to cloud IF running
     tests against a read-only file system (e.g. HTTP)"""
     cloud = session.config.getoption("--cloud")
+    if not cloud:
+        pytest.exit("FAIL: --cloud option is required")
+    if cloud not in ["local_s3", "http", "abfs"]:
+        pytest.exit(f"FAIL: Unsupported cloud type: {cloud}")
     if cloud in ("http"):
         skip_write = pytest.mark.skip(reason="Skipping write tests for read-only file system.")
         skip_range = pytest.mark.skip(reason="Skipping index tests for non-range reads.")

--- a/tests/data/indexed_files_http/csv_list_single.txt
+++ b/tests/data/indexed_files_http/csv_list_single.txt
@@ -1,0 +1,5 @@
+http://0.0.0.0:8000/raw/small_sky_parts/catalog_00_of_05.csv
+http://0.0.0.0:8000/raw/small_sky_parts/catalog_01_of_05.csv
+http://0.0.0.0:8000/raw/small_sky_parts/catalog_02_of_05.csv
+http://0.0.0.0:8000/raw/small_sky_parts/catalog_03_of_05.csv
+http://0.0.0.0:8000/raw/small_sky_parts/catalog_04_of_05.csv

--- a/tests/data/indexed_files_http/parquet_list_single.txt
+++ b/tests/data/indexed_files_http/parquet_list_single.txt
@@ -1,0 +1,4 @@
+http://0.0.0.0:8000/data/small_sky_order1/dataset/Norder=1/Dir=0/Npix=44.parquet
+http://0.0.0.0:8000/data/small_sky_order1/dataset/Norder=1/Dir=0/Npix=45.parquet
+http://0.0.0.0:8000/data/small_sky_order1/dataset/Norder=1/Dir=0/Npix=46.parquet
+http://0.0.0.0:8000/data/small_sky_order1/dataset/Norder=1/Dir=0/Npix=47.parquet

--- a/tests/hats/catalog/test_index_catalog.py
+++ b/tests/hats/catalog/test_index_catalog.py
@@ -1,9 +1,11 @@
 import numpy.testing as npt
+import pytest
 from hats.catalog.index.index_catalog import IndexCatalog
 from hats.loaders import read_hats
 from hats.pixel_math import HealpixPixel
 
 
+@pytest.mark.requires_range
 def test_loc_partition(small_sky_index_dir_cloud):
     catalog = read_hats(small_sky_index_dir_cloud)
 

--- a/tests/hats/io/file_io/test_file_io_cloud.py
+++ b/tests/hats/io/file_io/test_file_io_cloud.py
@@ -15,7 +15,7 @@ from hats.io.file_io import (
 from hats.io.paths import pixel_catalog_file
 from hats.pixel_math.healpix_pixel import HealpixPixel
 
-
+@pytest.mark.write_to_cloud
 def test_write_string_to_file(tmp_cloud_path):
     test_file_path = tmp_cloud_path / "text_file.txt"
     test_string = "this is a test"

--- a/tests/hats/io/file_io/test_file_io_cloud.py
+++ b/tests/hats/io/file_io/test_file_io_cloud.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+import pytest
 from hats.io import paths
 from hats.io.file_io import (
     load_csv_to_pandas,
@@ -31,6 +32,7 @@ def test_read_parquet_to_pandas(small_sky_dir_local, small_sky_dir_cloud):
     pd.testing.assert_frame_equal(parquet_df, loaded_df)
 
 
+@pytest.mark.write_to_cloud
 def test_write_df_to_csv(tmp_cloud_path):
     random_df = pd.DataFrame(np.random.randint(0, 100, size=(100, 4)), columns=list("ABCD"))
     test_file_path = tmp_cloud_path / "test.csv"
@@ -39,6 +41,7 @@ def test_write_df_to_csv(tmp_cloud_path):
     pd.testing.assert_frame_equal(loaded_df, random_df)
 
 
+@pytest.mark.write_to_cloud
 def test_load_csv_to_pandas_generator_encoding(tmp_cloud_path):
     path = tmp_cloud_path / "koi8-r.csv"
     with path.open(encoding="koi8-r", mode="w") as fh:
@@ -50,6 +53,7 @@ def test_load_csv_to_pandas_generator_encoding(tmp_cloud_path):
     assert num_reads == 1
 
 
+@pytest.mark.write_to_cloud
 def test_write_point_map_roundtrip(small_sky_dir_cloud, tmp_cloud_path):
     """Test the reading/writing of a catalog point map"""
     expected_counts_skymap = read_fits_image(paths.get_point_map_file_pointer(small_sky_dir_cloud))

--- a/tests/hats/io/file_io/test_file_io_cloud.py
+++ b/tests/hats/io/file_io/test_file_io_cloud.py
@@ -15,6 +15,7 @@ from hats.io.file_io import (
 from hats.io.paths import pixel_catalog_file
 from hats.pixel_math.healpix_pixel import HealpixPixel
 
+
 @pytest.mark.write_to_cloud
 def test_write_string_to_file(tmp_cloud_path):
     test_file_path = tmp_cloud_path / "text_file.txt"

--- a/tests/hats/io/test_write_metadata_cloud.py
+++ b/tests/hats/io/test_write_metadata_cloud.py
@@ -26,6 +26,7 @@ def basic_catalog_parquet_metadata():
     )
 
 
+@pytest.mark.write_to_cloud
 def test_write_parquet_metadata(tmp_cloud_path, small_sky_dir_cloud, basic_catalog_parquet_metadata):
     """Use existing catalog parquet files and create new metadata files for it"""
     catalog_base_dir = tmp_cloud_path
@@ -69,6 +70,7 @@ def check_parquet_schema(file_path, expected_schema, expected_num_row_groups=1):
             assert column_metadata.file_path.endswith(".parquet")
 
 
+@pytest.mark.write_to_cloud
 def test_read_write_fits_point_map(tmp_cloud_path):
     """Check that we write and can read a FITS file for spatial distribution."""
     initial_histogram = hist.empty_histogram(1)

--- a/tests/hats_import/test_create_margin.py
+++ b/tests/hats_import/test_create_margin.py
@@ -4,6 +4,7 @@ from hats import read_hats
 from hats_import.margin_cache.margin_cache_arguments import MarginCacheArguments
 
 
+@pytest.mark.write_to_cloud
 def test_margin_cache_gen(
     small_sky_order1_dir_local,
     tmp_path,

--- a/tests/hats_import/test_run_catalog_import.py
+++ b/tests/hats_import/test_run_catalog_import.py
@@ -9,6 +9,7 @@ from hats_import.catalog.file_readers import CsvReader
 from hats_cloudtests import assert_parquet_file_ids
 
 
+@pytest.mark.write_to_cloud
 @pytest.mark.dask
 def test_catalog_import_write_to_cloud(
     dask_client,

--- a/tests/hats_import/test_run_index.py
+++ b/tests/hats_import/test_run_index.py
@@ -1,10 +1,12 @@
 import hats_import.index.run_index as runner
 import pyarrow as pa
+import pytest
 from hats import read_hats
 from hats.io.file_io import read_parquet_metadata
 from hats_import.index.arguments import IndexArguments
 
 
+@pytest.mark.write_to_cloud
 def test_run_index(
     small_sky_order1_dir_local,
     tmp_path,

--- a/tests/hats_import/test_run_soap.py
+++ b/tests/hats_import/test_run_soap.py
@@ -5,6 +5,7 @@ from hats.io.file_io import read_parquet_metadata
 from hats_import.soap.arguments import SoapArguments
 
 
+@pytest.mark.write_to_cloud
 @pytest.mark.dask
 def test_object_to_self_write_to_cloud(
     dask_client,

--- a/tests/lsdb/catalog/test_index_search.py
+++ b/tests/lsdb/catalog/test_index_search.py
@@ -1,6 +1,8 @@
+import pytest
 from hats import read_hats
 
 
+@pytest.mark.requires_range
 def test_index_search(small_sky_order1_catalog_cloud, small_sky_index_dir_cloud):
     catalog_index = read_hats(small_sky_index_dir_cloud)
 

--- a/tests/lsdb/io/test_to_hats.py
+++ b/tests/lsdb/io/test_to_hats.py
@@ -1,7 +1,9 @@
 import lsdb
 import pandas as pd
+import pytest
 
 
+@pytest.mark.write_to_cloud
 def test_save_catalog_and_margin(local_data_dir, tmp_cloud_path):
     pathway = local_data_dir / "xmatch" / "xmatch_catalog_raw.csv"
     input_df = pd.read_csv(pathway)


### PR DESCRIPTION
Add a new testing fork for basic HTTP access of hats/lsdb/hats-import file access.

HTTP is assumed to be read-only, so this also adds a pytest mark to skip tests that try to write to cloud filesystems.

This testing spawned the following upstream PRs, so justifies having these tests, and running them nightly:

https://github.com/astronomy-commons/hats/pull/465
https://github.com/astronomy-commons/hats-import/pull/501
https://github.com/astronomy-commons/hats/pull/469

Supersedes https://github.com/astronomy-commons/hats-cloudtests/pull/60