### PR TITLE
Enforce lowest s3fs version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ requires-python = ">=3.10"
 dependencies = [
     # lsdb, hats, and hats-import are built from source via requirements.txt
     "adlfs",
-    "s3fs",
+    "s3fs>0.5",
     "moto[server]",
     "shortuuid",
 ]


### PR DESCRIPTION
Smoke test has failed the last two nights, and the dependency diff looks like:

Removed:
aiobotocore               2.21.1
aioitertools              0.12.0

Changed versions:
```
boto3                     1.37.1   ->  1.38.3
botocore                  1.37.1   ->  1.38.3
pip                       25.0.1   ->    25.1
s3fs                      2025.3.2 ->   0.4.2
s3transfer                0.11.3   ->  0.12.0
```

The s3fs dependency is super-suspicious, and there's even a dask warning that the version is just too old. The version they check in dask is < 0.5, so I figured that was a pretty safe lower bound for here as well. Could do some more playing around with it, after implementation of https://github.com/lincc-frameworks/python-project-template/issues/495, but this should address immediate failures.