### PR TITLE
Remove direct call to nested dask read_parquet

### DIFF
--- a/connectivity_tests/test_from_epyc.py
+++ b/connectivity_tests/test_from_epyc.py
@@ -1,6 +1,5 @@
-import lsdb.nested as nd
+import hats.io.file_io as file_io
 import numpy as np
-import pandas as pd
 
 
 def test_from_epyc():
@@ -8,27 +7,19 @@ def test_from_epyc():
     # Load some ZTF data
     catalogs_dir = "https://epyc.astro.washington.edu/~lincc-frameworks/half_degree_surveys/ztf/"
 
-    object_ndf = (
-        nd.read_parquet(f"{catalogs_dir}/ztf_object", columns=["ra", "dec", "ps1_objid"])
-        .set_index("ps1_objid", sort=True)
-        .persist()
-    )
+    object_ndf = file_io.read_parquet_file_to_pandas(
+        f"{catalogs_dir}/ztf_object/Norder=3/Dir=0/Npix=433.parquet", columns=["ra", "dec", "ps1_objid"]
+    ).set_index("ps1_objid")
 
-    source_ndf = (
-        nd.read_parquet(
-            f"{catalogs_dir}/ztf_source", columns=["mjd", "mag", "magerr", "band", "ps1_objid", "catflags"]
-        )
-        .set_index("ps1_objid", sort=True)
-        .persist()
-    )
+    source_ndf = file_io.read_parquet_file_to_pandas(
+        f"{catalogs_dir}/ztf_source/Norder=6/Dir=20000/Npix=27754.parquet",
+        columns=["mjd", "mag", "magerr", "band", "ps1_objid", "catflags"],
+    ).set_index("ps1_objid")
 
     object_ndf = object_ndf.join_nested(source_ndf, "ztf_source")
 
     # Apply a mean function
-    meta = pd.DataFrame(columns=[0], dtype=float)
-    result = object_ndf.map_rows(
-        np.mean, columns=["ztf_source.mag"], row_container="args", meta=meta
-    ).compute()
+    result = object_ndf.map_rows(np.mean, columns=["ztf_source.mag"], row_container="args")
 
     # just make sure the result was successfully computed
-    assert len(result) == 9817
+    assert len(result) == 1086


### PR DESCRIPTION
`lsdb.nested.read_parquet` was removed in https://github.com/astronomy-commons/lsdb/pull/1156, as it was not directly used within LSDB.

This test was initially written for some particular `map_partitions` testing, but is still useful for confirming behavior against this external dataset.