### PR TITLE
Reduce loads of cds vizcat catalogs in CI.

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -67,7 +67,7 @@ jobs:
     #     ABFS_LINCCDATA_ACCOUNT_NAME: ${{ secrets.LINCC_ABFS_ACCOUNT_NAME }}
     #     ABFS_LINCCDATA_ACCOUNT_KEY: ${{ secrets.LINCC_ABFS_ACCOUNT_KEY }}
     - name: Run connectivity tests
-      if: matrix.cloud == 'connectivity'
+      if: matrix.cloud == 'connectivity' and matrix.python-version == '3.14'
       run: |
         python -m pytest connectivity_tests
     - name: Send status to Slack app (LSDB CI Reporter)

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -22,8 +22,10 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.11', '3.12', '3.13', '3.14']
-        cloud: ['local_s3', 'local_gcs', 'http', 'connectivity']
-
+        cloud: ['local_s3', 'local_gcs', 'http']
+        include:
+          - python-version: '3.14'
+            cloud: 'connectivity'
     steps:
     - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
@@ -67,7 +69,7 @@ jobs:
     #     ABFS_LINCCDATA_ACCOUNT_NAME: ${{ secrets.LINCC_ABFS_ACCOUNT_NAME }}
     #     ABFS_LINCCDATA_ACCOUNT_KEY: ${{ secrets.LINCC_ABFS_ACCOUNT_KEY }}
     - name: Run connectivity tests
-      if: matrix.cloud == 'connectivity' && matrix.python-version == '3.14'
+      if: matrix.cloud == 'connectivity'
       run: |
         python -m pytest connectivity_tests
     - name: Send status to Slack app (LSDB CI Reporter)

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -67,7 +67,7 @@ jobs:
     #     ABFS_LINCCDATA_ACCOUNT_NAME: ${{ secrets.LINCC_ABFS_ACCOUNT_NAME }}
     #     ABFS_LINCCDATA_ACCOUNT_KEY: ${{ secrets.LINCC_ABFS_ACCOUNT_KEY }}
     - name: Run connectivity tests
-      if: matrix.cloud == 'connectivity' and matrix.python-version == '3.14'
+      if: matrix.cloud == 'connectivity' && matrix.python-version == '3.14'
       run: |
         python -m pytest connectivity_tests
     - name: Send status to Slack app (LSDB CI Reporter)

--- a/.github/workflows/testing-and-coverage.yml
+++ b/.github/workflows/testing-and-coverage.yml
@@ -59,6 +59,6 @@ jobs:
     #     ABFS_LINCCDATA_ACCOUNT_NAME: ${{ secrets.LINCC_ABFS_ACCOUNT_NAME }}
     #     ABFS_LINCCDATA_ACCOUNT_KEY: ${{ secrets.LINCC_ABFS_ACCOUNT_KEY }}
     - name: Run connectivity tests
-      if: matrix.cloud == 'connectivity'
+      if: matrix.cloud == 'connectivity' and matrix.python-version == '3.14'
       run: |
         python -m pytest connectivity_tests

--- a/.github/workflows/testing-and-coverage.yml
+++ b/.github/workflows/testing-and-coverage.yml
@@ -16,7 +16,10 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.11', '3.12', '3.13', '3.14']
-        cloud: ['local_s3', 'local_gcs', 'http', 'connectivity']
+        cloud: ['local_s3', 'local_gcs', 'http']
+        include:
+          - python-version: '3.14'
+            cloud: 'connectivity'
 
     steps:
     - uses: actions/checkout@v6
@@ -59,6 +62,6 @@ jobs:
     #     ABFS_LINCCDATA_ACCOUNT_NAME: ${{ secrets.LINCC_ABFS_ACCOUNT_NAME }}
     #     ABFS_LINCCDATA_ACCOUNT_KEY: ${{ secrets.LINCC_ABFS_ACCOUNT_KEY }}
     - name: Run connectivity tests
-      if: matrix.cloud == 'connectivity' && matrix.python-version == '3.14'
+      if: matrix.cloud == 'connectivity'
       run: |
         python -m pytest connectivity_tests

--- a/.github/workflows/testing-and-coverage.yml
+++ b/.github/workflows/testing-and-coverage.yml
@@ -59,6 +59,6 @@ jobs:
     #     ABFS_LINCCDATA_ACCOUNT_NAME: ${{ secrets.LINCC_ABFS_ACCOUNT_NAME }}
     #     ABFS_LINCCDATA_ACCOUNT_KEY: ${{ secrets.LINCC_ABFS_ACCOUNT_KEY }}
     - name: Run connectivity tests
-      if: matrix.cloud == 'connectivity' and matrix.python-version == '3.14'
+      if: matrix.cloud == 'connectivity' && matrix.python-version == '3.14'
       run: |
         python -m pytest connectivity_tests

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -24,26 +24,6 @@ class BenchmarksHTTP:
         self.gaia.compute()
 
 
-class BenchmarksCDSHTTP:
-    """Benchmark LSDB operations via CDS's HTTP."""
-
-    timeout = 600
-    rounds = 1
-    repeat = 2
-    number = 1
-
-    def setup(self):
-        # pylint: disable=attribute-defined-outside-init
-        self.gaia = lsdb.open_catalog(
-            "https://vizcat.cds.unistra.fr/hats:n=1000000/gaia_dr3/",
-            search_filter=lsdb.PixelSearch([(7, 114853)]),
-            columns=["DR3Name", "RA_ICRS", "DE_ICRS"],
-        )
-
-    def time_gaia(self):
-        self.gaia.compute()
-
-
 class BenchmarksS3:
     """Benchmark LSDB operations via S3."""
 


### PR DESCRIPTION
For each commit to a PR and main, and nightly, we would see:

- connectivity tests
  - 3.11
  - 3.12
  - 3.13
  - 3.14
- benchmarks
  - and a repeat

We really only need one connection test, with one python version. We see failed connections that are more likely just due to too many requests.