### PR TITLE
Fix vizcat connectivity test

### DIFF
--- a/connectivity_tests/test_from_vizcat.py
+++ b/connectivity_tests/test_from_vizcat.py
@@ -4,7 +4,6 @@ import lsdb
 def test_from_vizcat():
     gaia = lsdb.open_catalog(
         "https://vizcat.cds.unistra.fr/hats:n=10000/gaia_dr3/",
-        search_filter=lsdb.PixelSearch([(7, 114853)]),
         columns=["DR3Name", "RA_ICRS", "DE_ICRS"],
     )
     head_frame = gaia.head(10)


### PR DESCRIPTION
The vizcat service does not support pyarrow filters using the __healpix_29_ column (at least not directly) since this column is generated on the fly. We can safely remove this pixel search from the connectivity test to prevent sending those over.