### PR TITLE
Check for dask compatibility in specific circumstance.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/astronomy-commons/hats.git@unquote_http
+git+https://github.com/astronomy-commons/hats.git@main
 git+https://github.com/astronomy-commons/hats-import.git@main
 git+https://github.com/astronomy-commons/lsdb.git@main
 git+https://github.com/lincc-frameworks/nested-pandas.git@main

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/astronomy-commons/hats.git@main
+git+https://github.com/astronomy-commons/hats.git@unquote_http
 git+https://github.com/astronomy-commons/hats-import.git@main
 git+https://github.com/astronomy-commons/lsdb.git@main
 git+https://github.com/lincc-frameworks/nested-pandas.git@main

--- a/tests/hats_import/test_run_index.py
+++ b/tests/hats_import/test_run_index.py
@@ -1,3 +1,5 @@
+import sys
+
 import hats_import.index.run_index as runner
 import pyarrow as pa
 import pytest
@@ -6,6 +8,7 @@ from hats.io.file_io import read_parquet_metadata
 from hats_import.index.arguments import IndexArguments
 
 
+@pytest.mark.skipif((3, 11) <= sys.version_info < (3, 12), reason="dask expr regression with python 3.11")
 @pytest.mark.write_to_cloud
 def test_run_index(
     small_sky_order1_dir_local,
@@ -53,6 +56,7 @@ def test_run_index(
     assert schema.equals(basic_index_parquet_schema, check_metadata=False)
 
 
+@pytest.mark.skipif((3, 11) <= sys.version_info < (3, 12), reason="dask expr regression with python 3.11")
 def test_run_index_read_from_cloud(small_sky_order1_catalog_dir_cloud, tmp_path, dask_client):
     """Test appropriate metadata is written"""
 


### PR DESCRIPTION
See: https://github.com/astronomy-commons/hats-import/pull/682 and https://github.com/astronomy-commons/hats-import/issues/655

The smoke test failure is expected, as we will not run the indexing pipeline if python==3.11 and dask is 2025.4 or newer, as there is a significant regression in our use of dask expr given that combination.