### PR TITLE
remove npd main requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 git+https://github.com/astronomy-commons/hats.git@main
 git+https://github.com/astronomy-commons/hats-import.git@main
 git+https://github.com/astronomy-commons/lsdb.git@main
-git+https://github.com/lincc-frameworks/nested-pandas.git@main

--- a/tests/lsdb/io/test_to_hats.py
+++ b/tests/lsdb/io/test_to_hats.py
@@ -27,7 +27,7 @@ def test_save_catalog(local_data_dir, tmp_cloud_path):
     # When saving a catalog with write_catalog, we update the hats_max_rows
     # to the maximum count of points per partition. In this case there
     # is only one with 111 rows, so that is the value we expect.
-    partition_sizes = catalog.map_partitions(len).compute()["result"]
+    partition_sizes = catalog.map_partitions(len).compute()
     assert max(partition_sizes) == 111
 
     assert_catalog_info_is_correct(


### PR DESCRIPTION
As recently done in LSDB/hats/hats-import

Also fixes a small syntax difference with latest LSDB, introduced by the new series implementation