### PR TITLE
Shorten slack messages

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -79,6 +79,7 @@ jobs:
       with:
         webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
         webhook-type: webhook-trigger
+        # For posting a rich message using Block Kit
         payload: |
           {
             "blocks": [

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -77,7 +77,6 @@ jobs:
       id: slack
       uses: slackapi/slack-github-action@v3
       with:
-        # For posting a rich message using Block Kit
         webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
         webhook-type: webhook-trigger
         payload: |

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -77,34 +77,17 @@ jobs:
       id: slack
       uses: slackapi/slack-github-action@v3
       with:
+        # For posting a rich message using Block Kit
         webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
         webhook-type: webhook-trigger
-        # For posting a rich message using Block Kit
         payload: |
           {
             "blocks": [
               {
-                "type": "header",
-                "text": {
-                  "type": "plain_text",
-                  "text": "HATS Cloud tests: ${{ matrix.python-version }} - ${{ matrix.cloud }}"
-                }
-              },
-              {
                 "type": "section",
                 "text": {
                   "type": "mrkdwn",
-                  "text": "GitHub Action build result: *${{ job.status }}* :${{ job.status }}:"
-                }
-              },
-              {
-                "type": "divider"
-              },
-              {
-                "type": "section",
-                "text": {
-                  "type": "mrkdwn",
-                  "text": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                  "text": ":${{ job.status }}: *${{ github.repository }}* <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|run #${{ github.run_number }}>"
                 }
               }
             ]

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -87,7 +87,7 @@ jobs:
                 "type": "section",
                 "text": {
                   "type": "mrkdwn",
-                  "text": ":${{ job.status }}: *${{ github.repository }}:* ${{ matrix.python-version }} - ${{ matrix.cloud }} <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|run #${{ github.run_number }}>"
+                  "text": ":${{ job.status }}: *${{ github.repository }}:* ${{ matrix.python-version }} - ${{ matrix.cloud }} (<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|run #${{ github.run_number }}>)"
                 }
               }
             ]

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -87,7 +87,7 @@ jobs:
                 "type": "section",
                 "text": {
                   "type": "mrkdwn",
-                  "text": ":${{ job.status }}: *${{ github.repository }}* <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|run #${{ github.run_number }}>"
+                  "text": ":${{ job.status }}: *${{ github.repository }}:* ${{ matrix.python-version }} - ${{ matrix.cloud }} <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|run #${{ github.run_number }}>"
                 }
               }
             ]


### PR DESCRIPTION
## Change Description
Shortens the smoke test notifications in slack

Changes made:
- removed the status string ("failure") as clutter, as the message is only triggered on failure
  - but I did keep the little siren icon we use, to still give the "failure" vibe
- shortened the link to the GitHub run
- moved everything to a single line

### Original version:
<b>LSDB smoke test</b> (APP)  10:56 AM
<b>HATS Cloud tests: 3.14 - connectivity</b>
GitHub Action build result: <b>failure</b> 🚨
<hr/>
<a href="https://github.com/astronomy-commons/hats-cloudtests/actions/runs/30339304514">https://github.com/astronomy-commons/hats-cloudtests/actions/runs/30339304514</a>

### Proposed change:
<b>LSDB smoke test</b> (APP)  10:56 AM
 🚨 **astronomy-commons/hats-cloudtests** [30339304514](https://github.com/astronomy-commons/hats-cloudtests/actions/runs/30339304514)